### PR TITLE
fix: handle surrounding whitespaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 	total := len(docs)
 	fmt.Printf("Found %d backlinks to process.\n", total)
 
-	re := regexp.MustCompile(`\[\[` + regexp.QuoteMeta(oldTitle) + `(?:\|([^\[\]]+))?\]\]`)
+	re := regexp.MustCompile(`\[\[[\t\f ]*` + regexp.QuoteMeta(oldTitle) + `[\t\f ]*(?:\|([^\[\]]+))?\]\]`)
 	for idx, doc := range docs {
 		text, editToken, err := getPageContent(domain, token, doc)
 		if err != nil {


### PR DESCRIPTION
`[[ ]]` 사이 문서명 양쪽에 공백이 있는 경우도 링크로 인식됨. ([예시](https://theseed.io/diff/EC1?uuid=5161ce30-fb04-4cf6-be2d-b089818b7311))